### PR TITLE
Fix - now multiple declaration of the same attribute will be always in the same order

### DIFF
--- a/src/ApiApproverTests/Class_attributes.cs
+++ b/src/ApiApproverTests/Class_attributes.cs
@@ -155,6 +155,19 @@ namespace ApiApproverTests
         }
 
         [Fact]
+        public void Should_handle_attribute_with_multiple_usages_support()
+        {
+            AssertPublicApi<ClassWithAttributeWithMultipleUsagesSupport>(
+@"namespace ApiApproverTests.Examples
+{
+    [ApiApproverTests.Examples.AttributeWithMultipleUsagesSupport(IntValue=0, StringValue=""ZZZ"")]
+    [ApiApproverTests.Examples.AttributeWithMultipleUsagesSupport(IntValue=1, StringValue=""MMM"")]
+    [ApiApproverTests.Examples.AttributeWithMultipleUsagesSupport(IntValue=2, StringValue=""AAA"")]
+    public class ClassWithAttributeWithMultipleUsagesSupport { }
+}");
+        }
+
+        [Fact]
         public void Should_handle_attribute_with_object_initialiser()
         {
             AssertPublicApi<ClassWithAttributeWithObjectInitialiser>(
@@ -285,6 +298,13 @@ namespace ApiApproverTests
 
         [AttributeWithStringArrayInitialiser("Hello", "world")]
         public class ClassWithAttributeWithStringArrayInitialiser
+        {
+        }
+
+        [AttributeWithMultipleUsagesSupport(IntValue = 0, StringValue = "ZZZ")]
+        [AttributeWithMultipleUsagesSupport(IntValue = 1, StringValue = "MMM")]
+        [AttributeWithMultipleUsagesSupport(IntValue = 2, StringValue = "AAA")]
+        public class ClassWithAttributeWithMultipleUsagesSupport
         {
         }
     }

--- a/src/ApiApproverTests/HelperTypes.cs
+++ b/src/ApiApproverTests/HelperTypes.cs
@@ -132,6 +132,13 @@ namespace ApiApproverTests.Examples
         }
     }
 
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    public class AttributeWithMultipleUsagesSupport : Attribute
+    {
+        public string StringValue;
+        public int IntValue;
+    }
+
     public class AttributeWithObjectArrayInitialiser : Attribute
     {
         public AttributeWithObjectArrayInitialiser(params object[] values)


### PR DESCRIPTION
Case:

    [MyAttribute(X)]
    [MyAttribute(Y)]
    [MyAttribute(Z)]
    class MyClass {
    ...
    }

Problem: order of attributes was not deterministic - test that passed on local PC was failing on build machine because of changed order. 

Solution: I haven't looked for the root cause - decided to just add secondary explicit sorting.