### PR TITLE
Namer fix + ignoring infoversion attribute

### DIFF
--- a/src/ApiApprover/ApiApprover.csproj
+++ b/src/ApiApprover/ApiApprover.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ApprovalTests">
-      <HintPath>..\packages\ApprovalTests.3.0.2\lib\net40\ApprovalTests.dll</HintPath>
+      <HintPath>..\packages\ApprovalTests.3.0.8\lib\net40\ApprovalTests.dll</HintPath>
     </Reference>
     <Reference Include="ApprovalUtilities">
-      <HintPath>..\packages\ApprovalUtilities.3.0.2\lib\net35\ApprovalUtilities.dll</HintPath>
+      <HintPath>..\packages\ApprovalUtilities.3.0.8\lib\net35\ApprovalUtilities.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil">
       <HintPath>..\packages\Mono.Cecil.0.9.5.4\lib\net40\Mono.Cecil.dll</HintPath>

--- a/src/ApiApprover/ExampleApiApprovalTest.cs
+++ b/src/ApiApprover/ExampleApiApprovalTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using ApprovalTests.Namers;
 using ApprovalTests.Reporters;
 
 // TODO: Example requires xunit + xunit.extensions to be installed
@@ -15,9 +16,10 @@ namespace ApiApprover
         [TheoryWithLimitedFailures(20)]
         [PropertyData("AssemblyPaths")]
         [UseReporter(typeof(DiffReporter))]
+        [UseApprovalSubdirectory("results")]
         public void approve_public_api(string assembly, string path)
         {
-            PublicApiApprover.ApprovePublicApi(Path.Combine(path, assembly), "results");
+            PublicApiApprover.ApprovePublicApi(Path.Combine(path, assembly));
         }
 
         public static IEnumerable<object[]> AssemblyPaths

--- a/src/ApiApprover/PublicApiApprover.cs
+++ b/src/ApiApprover/PublicApiApprover.cs
@@ -1,19 +1,14 @@
-﻿using System.Diagnostics;
-using System.IO;
+﻿using System.IO;
 using ApprovalTests;
-using ApprovalTests.Core;
+using ApprovalTests.Namers;
 using Mono.Cecil;
 
 namespace ApiApprover
 {
     public static class PublicApiApprover
     {
-        public static void ApprovePublicApi(string assemblyPath, string resultsPath = "")
+        public static void ApprovePublicApi(string assemblyPath)
         {
-            var callingMethodFrame = new StackTrace(true).GetFrame(1);
-            var sourcePath = Path.GetDirectoryName(callingMethodFrame.GetFileName()) ?? Path.GetTempPath();
-            sourcePath = Path.IsPathRooted(resultsPath) ? resultsPath : Path.Combine(sourcePath, resultsPath);
-
             var assemblyResolver = new DefaultAssemblyResolver();
             assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
 
@@ -26,20 +21,23 @@ namespace ApiApprover
 
             var publicApi = PublicApiGenerator.CreatePublicApiForAssembly(asm);
             var writer = new ApprovalTextWriter(publicApi, "cs");
-            var approvalNamer = new AssemblyPathNamer(assemblyPath, sourcePath);
+            var approvalNamer = new AssemblyPathNamer(assemblyPath);
             ApprovalTests.Approvals.Verify(writer, approvalNamer, ApprovalTests.Approvals.GetReporter());
         }
 
-        private class AssemblyPathNamer : IApprovalNamer
+        private class AssemblyPathNamer : UnitTestFrameworkNamer
         {
-            public AssemblyPathNamer(string assemblyPath, string sourcePath)
+            private readonly string name;
+
+            public AssemblyPathNamer(string assemblyPath)
             {
-                Name = Path.GetFileNameWithoutExtension(assemblyPath);
-                SourcePath = sourcePath;
+                name = Path.GetFileNameWithoutExtension(assemblyPath);
             }
 
-            public string SourcePath { get; private set; }
-            public string Name { get; private set; }
+            public override string Name
+            {
+                get { return name; }
+            }
         }
     }
 }

--- a/src/ApiApprover/PublicApiGenerator.cs
+++ b/src/ApiApprover/PublicApiGenerator.cs
@@ -385,6 +385,7 @@ namespace ApiApprover
             "System.Reflection.AssemblyCopyrightAttribute",
             "System.Reflection.AssemblyDescriptionAttribute",
             "System.Reflection.AssemblyFileVersionAttribute",
+            "System.Reflection.AssemblyInformationalVersionAttribute",
             "System.Reflection.AssemblyProductAttribute",
             "System.Reflection.AssemblyTitleAttribute",
             "System.Reflection.AssemblyTrademarkAttribute"

--- a/src/ApiApprover/packages.config
+++ b/src/ApiApprover/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ApprovalTests" version="3.0.2" targetFramework="net40" />
-  <package id="ApprovalUtilities" version="3.0.2" targetFramework="net40" />
+  <package id="ApprovalTests" version="3.0.8" targetFramework="net40" />
+  <package id="ApprovalUtilities" version="3.0.8" targetFramework="net40" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />

--- a/src/ApiApproverTests/Properties/AssemblyInfo.cs
+++ b/src/ApiApproverTests/Properties/AssemblyInfo.cs
@@ -30,3 +30,4 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0.0 Info")]


### PR DESCRIPTION
Namer fix: Instead of duplicating the logic in ApprovalTests for determining the path, I just had the custom namer inherit from the default one.

Also, added `AssemblyInformationalVersionAttribute` to the list of ignored attributes.