### PR TITLE
use App_Packages convention

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -7,6 +7,6 @@
     <ItemGroup>
       <Nuget Include="$(MSBuildProjectDirectory)\src\packages\NuGet.CommandLine.*\tools\NuGet.exe" />
     </ItemGroup>
-    <Exec Command='"@(Nuget)" pack "$(MSBuildProjectDirectory)\src\ApiApprover\ApiApprover.nuspec"' />
+    <Exec Command='"@(Nuget)" pack "$(MSBuildProjectDirectory)\src\ApiApprover\ApiApprover.nuspec" -Prop version=3.0.1' />
   </Target>
 </Project>

--- a/src/ApiApprover/ApiApprover.nuspec
+++ b/src/ApiApprover/ApiApprover.nuspec
@@ -2,11 +2,11 @@
 <package >
   <metadata>
     <id>ApiApprover</id>
-    <version>3.0.0</version>
+    <version>$version$</version>
     <title>Api Approver</title>
     <authors>Jake Ginnivan</authors>
     <owners>Jake Ginnivan</owners>
-    <projectUrl>http://jake.ginnivan.net/ApiApprover</projectUrl>
+    <projectUrl>http://jake.ginnivan.net/apiapprover/</projectUrl>
     <licenseUrl>https://github.com/JakeGinnivan/ApiApprover/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Simply add this package to add a test which generates a string of your public API, then sends it to Approval Tests to approve any public API changes.
@@ -26,8 +26,7 @@ Don't accidently miss a breaking API change and break semantic versioning again.
     </dependencies>
   </metadata>
   <files>
-    <file src="PublicApiApprover.cs" target="content" />
-    <file src="PublicApiGenerator.cs" target="content" />
-    <file src="ExampleApiApprovalTest.cs" target="content" />
+    <file src="PublicApiApprover.cs" target="content\App_Packages\ApiApprover.$version$\" />
+    <file src="PublicApiGenerator.cs" target="content\App_Packages\ApiApprover.$version$\" />
   </files>
 </package>


### PR DESCRIPTION
fixes #10

i also removed ExampleApiApprovalTest from the package. i think doco is a better place for that and it will break for anyone not using xunit