### PR TITLE
Rendering constants with CultureInfo.InvariantCulture

### DIFF
--- a/src/ApiApprover/PublicApiGenerator.cs
+++ b/src/ApiApprover/PublicApiGenerator.cs
@@ -10,6 +10,7 @@ using Microsoft.CSharp;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 using TypeAttributes = System.Reflection.TypeAttributes;
+using System.Globalization;
 
 // ReSharper disable CheckNamespace
 // ReSharper disable BitwiseOperatorOnEnumWithoutFlags
@@ -530,7 +531,7 @@ namespace ApiApprover
                 }
 
                 var name = parameter.HasConstant
-                    ? string.Format("{0} = {1}", parameter.Name, FormatParameterConstant(parameter))
+                    ? string.Format(CultureInfo.InvariantCulture, "{0} = {1}", parameter.Name, FormatParameterConstant(parameter))
                     : parameter.Name;
                 var expression = new CodeParameterDeclarationExpression(type, name)
                 {


### PR DESCRIPTION
Rendering constants with CultureInfo.InvariantCulture to avoid trouble with non en-\* systems. This issue came up while working with the [Humanizer project](https://github.com/Humanizr/Humanizer/pull/475).
