### PR TITLE
Correction of a copy-paste error when processing Properties

### DIFF
--- a/src/PublicApiGenerator/PublicApiGenerator.cs
+++ b/src/PublicApiGenerator/PublicApiGenerator.cs
@@ -643,7 +643,7 @@ namespace PublicApiGenerator
             }
             if (member.SetMethod != null && member.SetMethod.HasCustomAttributes)
             {
-                PopulateCustomAttributes(member.GetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"));
+                PopulateCustomAttributes(member.SetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"));
             }
 
             foreach (var parameter in member.Parameters)


### PR DESCRIPTION
GetMethod was passed to PopulateCustomAttributes instead of SetMethod
