### PR TITLE
Internal interfaces on class are not part of public API

### DIFF
--- a/src/ApiApproverTests/Class_hierarchy.cs
+++ b/src/ApiApproverTests/Class_hierarchy.cs
@@ -74,6 +74,19 @@ namespace ApiApproverTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_not_output_internal_interfaces_on_class()
+        {
+            AssertPublicApi<ClassWithInternalInterface>(
+@"namespace ApiApproverTests.Examples
+{
+    public class ClassWithInternalInterface
+    {
+        public ClassWithInternalInterface() { }
+    }
+}");
+        }
     }
 
     // ReSharper disable ClassNeverInstantiated.Global
@@ -112,6 +125,10 @@ namespace ApiApproverTests
         }
 
         public class DerivedFromClassWithInterfaces : ClassWithInterfaces
+        {
+        }
+
+        public class ClassWithInternalInterface : IInternalInterface
         {
         }
     }

--- a/src/PublicApiGenerator/PublicApiGenerator.cs
+++ b/src/PublicApiGenerator/PublicApiGenerator.cs
@@ -212,7 +212,10 @@ namespace PublicApiGenerator
                 else
                     declaration.BaseTypes.Add(CreateCodeTypeReference(publicType.BaseType));
             }
-            foreach (var @interface in publicType.Interfaces.OrderBy(i => i.FullName))
+            foreach(var @interface in publicType.Interfaces.OrderBy(i => i.FullName)
+                .Select(t => new { Reference = t, Definition = t.Resolve() })
+                .Where(t => ShouldIncludeType(t.Definition))
+                .Select(t => t.Reference))
                 declaration.BaseTypes.Add(CreateCodeTypeReference(@interface));
 
             foreach (var memberInfo in publicType.GetMembers().Where(ShouldIncludeMember).OrderBy(m => m.Name))


### PR DESCRIPTION
See

https://twitter.com/terrajobst/status/773905057909645315

Internal interfaces declared on a class are not part of the public API.
