### PR TITLE
Async keyword is not part of the public API

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -5,7 +5,7 @@
     <Message Text=" ===========Packaging code===========" Importance="High" />
 
     <PropertyGroup>
-      <Version>5.0.0</Version>
+      <Version>6.0.0</Version>
     </PropertyGroup>
     <ItemGroup>
       <Nuget Include="$(MSBuildProjectDirectory)\src\packages\NuGet.CommandLine.*\tools\NuGet.exe" />

--- a/src/ApiApproverTests/Method_async.cs
+++ b/src/ApiApproverTests/Method_async.cs
@@ -21,6 +21,34 @@ namespace ApiApproverTests
         }
 
         [Fact]
+        public void Should_output_async_method()
+        {
+            AssertPublicApi<MethodAsync>(
+@"namespace ApiApproverTests.Examples
+{
+    public class MethodAsync
+    {
+        public MethodAsync() { }
+        public async System.Threading.Tasks.Task AsyncMethod() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_async_method_without_keyword()
+        {
+            AssertPublicApi<MethodAsyncWithoutAsyncKeyword>(
+@"namespace ApiApproverTests.Examples
+{
+    public class MethodAsyncWithoutAsyncKeyword
+    {
+        public MethodAsyncWithoutAsyncKeyword() { }
+        public System.Threading.Tasks.Task AsyncMethod() { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_output_async_method_with_return_value()
         {
             AssertPublicApi<MethodAsyncReturnValue>(
@@ -30,6 +58,20 @@ namespace ApiApproverTests
     {
         public MethodAsyncReturnValue() { }
         public async System.Threading.Tasks.Task<string> AsyncMethod() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_async_method_without_keyword_with_return_value()
+        {
+            AssertPublicApi<MethodAsyncReturnValueWithoutAsyncKeyword>(
+@"namespace ApiApproverTests.Examples
+{
+    public class MethodAsyncReturnValueWithoutAsyncKeyword
+    {
+        public MethodAsyncReturnValueWithoutAsyncKeyword() { }
+        public System.Threading.Tasks.Task<string> AsyncMethod() { }
     }
 }");
         }
@@ -48,11 +90,34 @@ namespace ApiApproverTests
             }
         }
 
+        public class MethodAsync
+        {
+            public async Task AsyncMethod()
+            {
+            }
+        }
+
+        public class MethodAsyncWithoutAsyncKeyword
+        {
+            public Task AsyncMethod()
+            {
+                return Task.FromResult(0);
+            }
+        }
+
         public class MethodAsyncReturnValue
         {
             public async Task<string> AsyncMethod()
             {
                 return await Task.FromResult("Hello world");
+            }
+        }
+
+        public class MethodAsyncReturnValueWithoutAsyncKeyword
+        {
+            public Task<string> AsyncMethod()
+            {
+                return Task.FromResult("Hello world");
             }
         }
     }

--- a/src/ApiApproverTests/Method_async.cs
+++ b/src/ApiApproverTests/Method_async.cs
@@ -15,7 +15,7 @@ namespace ApiApproverTests
     public class MethodAsyncVoid
     {
         public MethodAsyncVoid() { }
-        public async void AsyncMethod() { }
+        public void AsyncMethod() { }
     }
 }");
         }
@@ -29,7 +29,7 @@ namespace ApiApproverTests
     public class MethodAsync
     {
         public MethodAsync() { }
-        public async System.Threading.Tasks.Task AsyncMethod() { }
+        public System.Threading.Tasks.Task AsyncMethod() { }
     }
 }");
         }
@@ -57,7 +57,7 @@ namespace ApiApproverTests
     public class MethodAsyncReturnValue
     {
         public MethodAsyncReturnValue() { }
-        public async System.Threading.Tasks.Task<string> AsyncMethod() { }
+        public System.Threading.Tasks.Task<string> AsyncMethod() { }
     }
 }");
         }

--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -484,8 +484,6 @@ namespace PublicApiGenerator
                 return;
 
             var returnType = CreateCodeTypeReference(member.ReturnType);
-            if (IsAsyncMethod(member))
-                returnType = MakeAsync(returnType);
 
             var method = new CodeMemberMethod
             {
@@ -499,11 +497,6 @@ namespace PublicApiGenerator
             PopulateMethodParameters(member, method.Parameters, IsExtensionMethod(member));
 
             typeDeclaration.Members.Add(method);
-        }
-
-        static bool IsAsyncMethod(ICustomAttributeProvider method)
-        {
-            return method.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.AsyncStateMachineAttribute");
         }
 
         static bool IsExtensionMethod(ICustomAttributeProvider method)
@@ -749,11 +742,6 @@ namespace PublicApiGenerator
         static CodeTypeReference MakeReadonly(CodeTypeReference typeReference)
         {
             return ModifyCodeTypeReference(typeReference, "readonly");
-        }
-
-        static CodeTypeReference MakeAsync(CodeTypeReference typeReference)
-        {
-            return ModifyCodeTypeReference(typeReference, "async");
         }
 
         static CodeTypeReference ModifyCodeTypeReference(CodeTypeReference typeReference, string modifier)

--- a/src/PublicApiGenerator/PublicApiGenerator.nuspec
+++ b/src/PublicApiGenerator/PublicApiGenerator.nuspec
@@ -13,6 +13,8 @@
     <copyright>Copyright Jake Ginnivan 2015</copyright>
     <tags>semanticversioning versioning api</tags>
     <releaseNotes>
+      v6.0 Breaking changes:
+      - The async keyword doesn't influence the public API and therefore is no longer treated as part of the public API.    
       v5.0 Breaking changes:
       - Converted to source only package
       - Invariant Culture used for string.Format


### PR DESCRIPTION
Closes #19 

The async keyword should not be part of the public API at all.

The async keyword is an implementation detail since it is just syntactic sugar. From an API perspective the following APIs are equivalent:

- `async void` vs. `void`
- `async Task` vs `Task`
- `async Task<T>` vs `Task<T>`

From a behavior perspective you could argue that the runtime behavior from `void` to `async void` can change and therefore it could be a breaking change but from an API perspective both APIs are binary compatible. Since API approver's concern is only the public API the `async` keyword should be omitted. 