### PR TITLE
Add support for contentFiles

### DIFF
--- a/src/ApiApprover/ApiApprover.nuspec
+++ b/src/ApiApprover/ApiApprover.nuspec
@@ -17,7 +17,7 @@ Don't accidently miss a breaking API change and break semantic versioning again.
       v3.0 Breaking changes:
       - Default constructor is now always shown
       - resultsPath argument removed, use [UseApprovalSubdirectory("resultsPath")] instead
-	  v3.0.1 - Moved file location to fit with http://nikcodes.com/2013/10/23/packaging-source-code-with-nuget
+      v3.0.1 - Moved file location to fit with http://nikcodes.com/2013/10/23/packaging-source-code-with-nuget
     </releaseNotes>
     <copyright>Copyright Jake Ginnivan 2015</copyright>
     <tags>semanticversioning versioning approve api</tags>
@@ -28,5 +28,6 @@ Don't accidently miss a breaking API change and break semantic versioning again.
   </metadata>
   <files>
     <file src="PublicApiApprover.cs" target="content\App_Packages\ApiApprover.$version$\" />
+    <file src="PublicApiApprover.cs" target="contentFiles\cs\any\ApiApprover\" />
   </files>
 </package>

--- a/src/PublicApiGenerator/PublicApiGenerator.nuspec
+++ b/src/PublicApiGenerator/PublicApiGenerator.nuspec
@@ -26,5 +26,6 @@
   </metadata>
   <files>
     <file src="ApiGenerator.cs" target="content\App_Packages\PublicApiGenerator.$version$\" />
+    <file src="ApiGenerator.cs" target="contentFiles\cs\any\PublicApiGenerator\" />
   </files>
 </package>


### PR DESCRIPTION
@danielmarbach This updates the nuspec files to include the source files in the `contentFiles` folder as well as `content`. This let the packages work when installed in a project that uses NuGet's transitive restore mechanism, for example via PackageReference in the new SDK-style csproj format.

I've intentionally removed the version number from the `contentFiles` path because these will be refereenced from the NuGet package cache folder, which already includes the version number.