### PR TITLE
Add AppDomain.CurrentDomain.BaseDirectory to assembly search path

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
@@ -25,7 +25,8 @@ namespace PublicApiGenerator
             {
                 var assemblyPath = assemby.Location;
                 assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
-
+                assemblyResolver.AddSearchDirectory(AppDomain.CurrentDomain.BaseDirectory);
+                
                 var readSymbols = File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
                 using (var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters(ReadingMode.Deferred)
                 {


### PR DESCRIPTION
NUnit creates a lot of directories for the assemblies, meaning it's hard for the ApiGenerator to find dependencies. By adding *AppDomain.CurrentDomain.BaseDirectory* as search directory, it will have the *actual output directory* of the test project as search directory making sure that dependencies can be found when running using NUnit.