### PR TITLE
Fix whitelisting System namespaces

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -135,7 +135,7 @@ namespace PublicApiGenerator
             if (m.DeclaringType?.FullName == null)
                 return false;
 
-            return m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft")
+            return (m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft"))
                 && !whitelistedNamespacePrefixes.Any(prefix => m.DeclaringType.FullName.StartsWith(prefix));
         }
 

--- a/src/PublicApiGeneratorTests/Namespaces_whitelisting.cs
+++ b/src/PublicApiGeneratorTests/Namespaces_whitelisting.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Whitelisted;
+using System.Whitelisted;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -6,20 +7,63 @@ namespace PublicApiGeneratorTests
     public class Namespaces_whitelisting : ApiGeneratorTestsBase
     {
         [Fact]
-        public void Should_allow_namespace_whitelisting()
+        public void Should_allow_microsoft_namespace_whitelisting()
         {
-            AssertPublicApi(new[] {typeof(Simple1), typeof(Simple2)},
+            AssertPublicApi(new[] { typeof(Simple1), typeof(Simple2) },
                 @"namespace Microsoft.Whitelisted
 {
     public class Simple1
     {
         public Simple1() { }
+        public void Simple() { }
     }
     public class Simple2
     {
         public Simple2() { }
+        public void Simple() { }
     }
 }", whitelistedNamespacePrefixes: new[] { "Microsoft.Whitelisted" });
+        }
+
+        [Fact]
+        public void Should_filter_microsoft_namespace()
+        {
+            AssertPublicApi(new[] { typeof(Simple1), typeof(Simple2) },
+                @"namespace Microsoft.Whitelisted
+{
+    public class Simple1 { }
+    public class Simple2 { }
+}");
+        }
+
+        [Fact]
+        public void Should_allow_system_namespace_whitelisting()
+        {
+            AssertPublicApi(new[] { typeof(System1), typeof(System2)},
+                @"namespace System.Whitelisted
+{
+    public class System1
+    {
+        public System1() { }
+        public void System() { }
+    }
+    public class System2
+    {
+        public System2() { }
+        public void System() { }
+    }
+}", whitelistedNamespacePrefixes: new[] { "System.Whitelisted" });
+        }
+
+        [Fact]
+        public void Should_filter_system_namespace()
+        {
+            AssertPublicApi(new[] { typeof(System1), typeof(System2) },
+                @"namespace System.Whitelisted
+{
+    public class System1 { }
+    public class System2 { }
+}");
         }
     }
 }
@@ -28,9 +72,24 @@ namespace Microsoft.Whitelisted
 {
     public class Simple1
     {
+        public void Simple() { }
     }
 
     public class Simple2
     {
+        public void Simple() { }
+    }
+}
+
+namespace System.Whitelisted
+{
+    public class System1
+    {
+        public void System() { }
+    }
+
+    public class System2
+    {
+        public void System() { }
     }
 }


### PR DESCRIPTION
I noticed that while whitelisting works for "Microsoft" prefixes it wasn't allowing whitelisting to override the filtering of "System" prefixes.