### PR TITLE
Include operators in api generation

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -510,17 +510,50 @@ namespace PublicApiGenerator
             typeDeclaration.Members.Add(method);
         }
 
+        static readonly IDictionary<string, string> OperatorNameMap = new Dictionary<string, string>
+        {
+            { "op_Addition", "+" },
+            { "op_UnaryPlus", "+" },
+            { "op_Subtraction", "-" },
+            { "op_UnaryNegation", "-" },
+            { "op_Multiply", "*" },
+            { "op_Division", "/" },
+            { "op_Modulus", "%" },
+            { "op_Increment", "++" },
+            { "op_Decrement", "--" },
+            { "op_OnesComplement", "~" },
+            { "op_LogicalNot", "!" },
+            { "op_BitwiseAnd", "&" },
+            { "op_BitwiseOr", "|" },
+            { "op_ExclusiveOr", "^" },
+            { "op_LeftShift", "<<" },
+            { "op_RightShift", ">>" },
+            { "op_Equality", "==" },
+            { "op_Inequality", "!=" },
+            { "op_GreaterThan", ">" },
+            { "op_GreaterThanOrEqual", ">=" },
+            { "op_LessThan", "<" },
+            { "op_LessThanOrEqual", "<=" }
+        };
+
         static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member, HashSet<string> excludeAttributes)
         {
+            if (member.IsAssembly || member.IsPrivate) return;
+
             var isOperator = member.Name.StartsWith("op_");
-            if (member.IsAssembly || member.IsPrivate || (member.IsSpecialName && !isOperator))
-                return;
+            if (member.IsSpecialName && !isOperator) return;
+
+            var memberName = member.Name;
+            if (isOperator && OperatorNameMap.ContainsKey(memberName))
+            {
+                memberName = OperatorNameMap[memberName];
+            }
 
             var returnType = CreateCodeTypeReference(member.ReturnType);
 
             var method = new CodeMemberMethod
             {
-                Name = member.Name,
+                Name = memberName,
                 Attributes = GetMethodAttributes(member),
                 CustomAttributes = CreateCustomAttributes(member, excludeAttributes),
                 ReturnType = returnType,

--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -512,7 +512,8 @@ namespace PublicApiGenerator
 
         static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member, HashSet<string> excludeAttributes)
         {
-            if (member.IsAssembly || member.IsPrivate || member.IsSpecialName)
+            var isOperator = member.Name.StartsWith("op_");
+            if (member.IsAssembly || member.IsPrivate || (member.IsSpecialName && !isOperator))
                 return;
 
             var returnType = CreateCodeTypeReference(member.ReturnType);

--- a/src/PublicApiGeneratorTests/Operator_order.cs
+++ b/src/PublicApiGeneratorTests/Operator_order.cs
@@ -6,7 +6,7 @@ namespace PublicApiGeneratorTests
     public class Operator_order : ApiGeneratorTestsBase
     {
         [Fact]
-        public void Should_show_custom_operators()
+        public void Should_sort_unary_operators()
         {
             AssertPublicApi<ClassWithUnaryOperators>(
 @"namespace PublicApiGeneratorTests.Examples
@@ -14,16 +14,56 @@ namespace PublicApiGeneratorTests
     public class ClassWithUnaryOperators
     {
         public ClassWithUnaryOperators() { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Addition(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Decrement(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Division(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators --(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
         public static bool op_False(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Increment(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_LogicalNot(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Multiply(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_OnesComplement(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Subtraction(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators ++(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators !(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators ~(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
         public static bool op_True(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators -(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators +(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_sort_binary_operators()
+        {
+            AssertPublicApi<ClassWithBinaryOperators>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithBinaryOperators
+    {
+        public ClassWithBinaryOperators() { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators +(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators &(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators |(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators /(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators ^(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators <<(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, int second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators %(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators *(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators >>(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, int second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators -(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_sort_comparison_operators()
+        {
+            AssertPublicApi<ClassWithComparisonOperators>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithComparisonOperators
+    {
+        public ClassWithComparisonOperators() { }
+        public static bool ==(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool >(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool >=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool !=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool <(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool <=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
     }
 }");
         }
@@ -33,16 +73,38 @@ namespace PublicApiGeneratorTests
     {
         public class ClassWithUnaryOperators
         {
-            public static ClassWithUnaryOperators operator +(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
-            public static ClassWithUnaryOperators operator -(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
-            public static ClassWithUnaryOperators operator /(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
-            public static ClassWithUnaryOperators operator *(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
+            public static ClassWithUnaryOperators operator +(ClassWithUnaryOperators first) => first;
+            public static ClassWithUnaryOperators operator -(ClassWithUnaryOperators first) => first;
             public static ClassWithUnaryOperators operator !(ClassWithUnaryOperators first) => first;
             public static ClassWithUnaryOperators operator ~(ClassWithUnaryOperators first) => first;
             public static ClassWithUnaryOperators operator ++(ClassWithUnaryOperators first) => first;
             public static ClassWithUnaryOperators operator --(ClassWithUnaryOperators first) => first;
             public static bool operator true(ClassWithUnaryOperators first) => true;
             public static bool operator false(ClassWithUnaryOperators first) => false;
+        }
+
+        public class ClassWithBinaryOperators
+        {
+            public static ClassWithBinaryOperators operator +(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator -(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator /(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator *(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator %(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator &(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator |(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator ^(ClassWithBinaryOperators first, ClassWithBinaryOperators second) => first;
+            public static ClassWithBinaryOperators operator <<(ClassWithBinaryOperators first, int second) => first;
+            public static ClassWithBinaryOperators operator >>(ClassWithBinaryOperators first, int second) => first;
+        }
+
+        public class ClassWithComparisonOperators
+        {
+            public static bool operator ==(ClassWithComparisonOperators first, ClassWithComparisonOperators second) => true;
+            public static bool operator !=(ClassWithComparisonOperators first, ClassWithComparisonOperators second) => true;
+            public static bool operator <(ClassWithComparisonOperators first, ClassWithComparisonOperators second) => true;
+            public static bool operator >(ClassWithComparisonOperators first, ClassWithComparisonOperators second) => true;
+            public static bool operator <=(ClassWithComparisonOperators first, ClassWithComparisonOperators second) => true;
+            public static bool operator >=(ClassWithComparisonOperators first, ClassWithComparisonOperators second) => true;
         }
     }
 }

--- a/src/PublicApiGeneratorTests/Operator_order.cs
+++ b/src/PublicApiGeneratorTests/Operator_order.cs
@@ -1,0 +1,48 @@
+﻿using PublicApiGeneratorTests.Examples;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Operator_order : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_show_custom_operators()
+        {
+            AssertPublicApi<ClassWithUnaryOperators>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithUnaryOperators
+    {
+        public ClassWithUnaryOperators() { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Addition(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Decrement(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Division(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
+        public static bool op_False(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Increment(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_LogicalNot(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Multiply(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_OnesComplement(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators op_Subtraction(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first, PublicApiGeneratorTests.Examples.ClassWithUnaryOperators second) { }
+        public static bool op_True(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+    }
+}");
+        }
+    }
+
+    namespace Examples
+    {
+        public class ClassWithUnaryOperators
+        {
+            public static ClassWithUnaryOperators operator +(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
+            public static ClassWithUnaryOperators operator -(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
+            public static ClassWithUnaryOperators operator /(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
+            public static ClassWithUnaryOperators operator *(ClassWithUnaryOperators first, ClassWithUnaryOperators second) => second;
+            public static ClassWithUnaryOperators operator !(ClassWithUnaryOperators first) => first;
+            public static ClassWithUnaryOperators operator ~(ClassWithUnaryOperators first) => first;
+            public static ClassWithUnaryOperators operator ++(ClassWithUnaryOperators first) => first;
+            public static ClassWithUnaryOperators operator --(ClassWithUnaryOperators first) => first;
+            public static bool operator true(ClassWithUnaryOperators first) => true;
+            public static bool operator false(ClassWithUnaryOperators first) => false;
+        }
+    }
+}

--- a/src/PublicApiGeneratorTests/Operator_visibility.cs
+++ b/src/PublicApiGeneratorTests/Operator_visibility.cs
@@ -1,0 +1,30 @@
+﻿using PublicApiGeneratorTests.Examples;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Operator_visibility : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_show_custom_operators()
+        {
+            AssertPublicApi<ClassWithOperator>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithOperator
+    {
+        public ClassWithOperator() { }
+        public static PublicApiGeneratorTests.Examples.ClassWithOperator op_Addition(PublicApiGeneratorTests.Examples.ClassWithOperator first, PublicApiGeneratorTests.Examples.ClassWithOperator second) { }
+    }
+}");
+        }
+    }
+
+    namespace Examples
+    {
+        public class ClassWithOperator
+        {
+            public static ClassWithOperator operator +(ClassWithOperator first, ClassWithOperator second) => second;
+        }
+    }
+}

--- a/src/PublicApiGeneratorTests/Operator_visibility.cs
+++ b/src/PublicApiGeneratorTests/Operator_visibility.cs
@@ -14,7 +14,7 @@ namespace PublicApiGeneratorTests
     public class ClassWithOperator
     {
         public ClassWithOperator() { }
-        public static PublicApiGeneratorTests.Examples.ClassWithOperator op_Addition(PublicApiGeneratorTests.Examples.ClassWithOperator first, PublicApiGeneratorTests.Examples.ClassWithOperator second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithOperator +(PublicApiGeneratorTests.Examples.ClassWithOperator first, PublicApiGeneratorTests.Examples.ClassWithOperator second) { }
     }
 }");
         }


### PR DESCRIPTION
I noticed that operators are not currently included in the generated public api surface whereas I would expect operators to be included. This was the result of `IsSpecialName` returning `true` for operators.

Unfortunately there doesn't appear to be a good way to tell whether this is a "special name" that should be included or not (such as the case for operators). I confess I'm not sure what all falls under the "special name" category. The best differentiator I could find [was sources claiming that all operator names are formatted as "op_*"](https://stackoverflow.com/a/3016653/558700) so I leveraged that for determining if a given method is an operator. I'm very open to alternatives that can be more precise without needing to rely on string comparisons.

I'm willing to write more tests but I wasn't sure what would be overkill. I tried to mirror the `Method_*.cs` test files to a degree.