### PR TITLE
Updates

### DIFF
--- a/src/ApiApprover.sln
+++ b/src/ApiApprover.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\build.ps1 = ..\build.ps1
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
+		GitVersionWorkaround.targets = GitVersionWorkaround.targets
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject

--- a/src/ApiApprover/ApiApprover.csproj
+++ b/src/ApiApprover/ApiApprover.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
+    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="AddPackageContent" BeforeTargets="GenerateNuspec">
@@ -27,7 +28,5 @@
       </_PackageFiles>
     </ItemGroup>
   </Target>
-
-  <Import Project="../GitVersionWorkaround.targets" />
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/GitVersionWorkaround.targets
+++ b/src/GitVersionWorkaround.targets
@@ -1,18 +1,9 @@
 <Project>
 
-  <!-- Workaround because of https://github.com/NuGet/Home/issues/4790 -->
+  <!-- Workaround because https://github.com/GitTools/GitVersion/pull/1351 hasn't been released yet -->
   <PropertyGroup>
-    <GitVersionTaskVersion>4.0.0-beta0012</GitVersionTaskVersion>
+    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);GetVersion</GetPackageVersionDependsOn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="$(GitVersionTaskVersion)" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ImportGroup Condition="'$(ExcludeRestorePackageImports)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">
-    <Import Project="$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets" Condition="Exists('$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets')" />
-  </ImportGroup>
-  <Target Name="FixUpVersion" BeforeTargets="_GenerateRestoreProjectSpec" DependsOnTargets="GetVersion" Condition="'$(GitVersion_Task_targets_Imported)' == 'True'" />
   <!-- End Workaround -->
 
 </Project>

--- a/src/PublicApiGenerator/PublicApiGenerator.csproj
+++ b/src/PublicApiGenerator/PublicApiGenerator.csproj
@@ -9,11 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.CodeDom" Version="4.4.0" />
+    <PackageReference Include="System.CodeDom" Version="4.5.0" />
   </ItemGroup>
 
   <Target Name="AddPackageContent" BeforeTargets="GenerateNuspec">

--- a/src/PublicApiGenerator/PublicApiGenerator.csproj
+++ b/src/PublicApiGenerator/PublicApiGenerator.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
   </ItemGroup>
 

--- a/src/PublicApiGeneratorTests/PublicApiGeneratorTests.csproj
+++ b/src/PublicApiGeneratorTests/PublicApiGeneratorTests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This cleans up the GitVersion workaround to the latest version that is needed.

It also updates packages, including going to the non-prelease version of Mono.Cecil.