### PR TITLE
Update Mono.Cecil to 0.10.1 to allow Embedded debug type

### DIFF
--- a/src/PublicApiGenerator/PublicApiGenerator.csproj
+++ b/src/PublicApiGenerator/PublicApiGenerator.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0012" PrivateAssets="All" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
At the moment 0.10 of Cecil only supports portable PDB and full PDBs

They added support for the embedded files in v0.10.1 version of Mono.Cecil

Updating the reference to allow for this.

The current workaround is easy in terms of I can just update my project but thought others might benefit from this.

Thanks :)