### PR TITLE
 Use StringComparer.Ordinal instead of linguistic culture aware ordering which can lead to different results depending on the environment

### DIFF
--- a/src/PublicApiGeneratorTests/Assembly_member_ordering.cs
+++ b/src/PublicApiGeneratorTests/Assembly_member_ordering.cs
@@ -13,11 +13,17 @@ namespace PublicApiGeneratorTests
             AssertPublicApi(new[]
             {
                 typeof(AssemblyMember_Delegate2),
+                typeof(AssemblyMember_IDelegate2),
+                typeof(AssemblyMember_ClassI),
+                typeof(AssemblyMember_Classi),
                 typeof(IAssemblyMember_Interface1),
+                typeof(IAssemblyMember_interface1),
                 typeof(AssemblyMember_Class2),
                 typeof(IAssemblyMember_Interface2),
+                typeof(IAssemblyMember_interface2),
                 typeof(AssemblyMember_Class1),
-                typeof(AssemblyMember_Delegate1)
+                typeof(AssemblyMember_Delegate1),
+                typeof(AssemblyMember_iDelegate1)
             },
 @"namespace PublicApiGeneratorTests.Examples
 {
@@ -29,10 +35,22 @@ namespace PublicApiGeneratorTests
     {
         public AssemblyMember_Class2() { }
     }
+    public class AssemblyMember_ClassI
+    {
+        public AssemblyMember_ClassI() { }
+    }
+    public class AssemblyMember_Classi
+    {
+        public AssemblyMember_Classi() { }
+    }
     public delegate void AssemblyMember_Delegate1();
     public delegate void AssemblyMember_Delegate2();
+    public delegate void AssemblyMember_IDelegate2();
+    public delegate void AssemblyMember_iDelegate1();
     public interface IAssemblyMember_Interface1 { }
     public interface IAssemblyMember_Interface2 { }
+    public interface IAssemblyMember_interface1 { }
+    public interface IAssemblyMember_interface2 { }
 }");
         }
 
@@ -42,7 +60,9 @@ namespace PublicApiGeneratorTests
             AssertPublicApi(new[]
             {
                 typeof(AssemblyOrdering_1),
-                typeof(AssemblyOrdering_2)
+                typeof(AssemblyOrdering_2),
+                typeof(Examples_I.AssemblyOrdering_2),
+                typeof(Examples_i.AssemblyOrdering_1),
             },
 @"namespace PublicApiGeneratorTests.Examples_AA
 {
@@ -51,7 +71,21 @@ namespace PublicApiGeneratorTests
         public AssemblyOrdering_2() { }
     }
 }
+namespace PublicApiGeneratorTests.Examples_I
+{
+    public class AssemblyOrdering_2
+    {
+        public AssemblyOrdering_2() { }
+    }
+}
 namespace PublicApiGeneratorTests.Examples_ZZ
+{
+    public class AssemblyOrdering_1
+    {
+        public AssemblyOrdering_1() { }
+    }
+}
+namespace PublicApiGeneratorTests.Examples_i
 {
     public class AssemblyOrdering_1
     {
@@ -73,7 +107,19 @@ namespace PublicApiGeneratorTests.Examples_ZZ
         {
         }
 
+        public class AssemblyMember_ClassI
+        {
+        }
+
+        public class AssemblyMember_Classi
+        {
+        }
+
         public interface IAssemblyMember_Interface2
+        {
+        }
+
+        public interface IAssemblyMember_interface2
         {
         }
 
@@ -81,8 +127,14 @@ namespace PublicApiGeneratorTests.Examples_ZZ
         {
         }
 
+        public interface IAssemblyMember_interface1
+        {
+        }
+
         public delegate void AssemblyMember_Delegate2();
         public delegate void AssemblyMember_Delegate1();
+        public delegate void AssemblyMember_IDelegate2();
+        public delegate void AssemblyMember_iDelegate1();
     }
 
     namespace Examples_AA
@@ -93,6 +145,20 @@ namespace PublicApiGeneratorTests.Examples_ZZ
     }
 
     namespace Examples_ZZ
+    {
+        public class AssemblyOrdering_1
+        {
+        }
+    }
+
+    namespace Examples_I
+    {
+        public class AssemblyOrdering_2
+        {
+        }
+    }
+
+    namespace Examples_i
     {
         public class AssemblyOrdering_1
         {

--- a/src/PublicApiGeneratorTests/Class_member_order.cs
+++ b/src/PublicApiGeneratorTests/Class_member_order.cs
@@ -17,15 +17,25 @@ namespace PublicApiGeneratorTests
     {
         public int Field1;
         public int Field2;
+        public int IField1;
+        public int iField2;
         public ClassMemberOrder() { }
+        public int IProperty1 { get; set; }
         public int Property1 { get; set; }
         public int Property2 { get; set; }
+        public int iProperty2 { get; set; }
         public event System.EventHandler Event1;
         public event System.EventHandler Event2;
+        public event System.EventHandler IEvent1;
+        public event System.EventHandler iEvent2;
+        public void IMethod1() { }
         public void Method1() { }
         public void Method2() { }
+        public void iMethod2() { }
         public delegate System.EventHandler Delegate1();
         public delegate System.EventHandler Delegate2();
+        public delegate System.EventHandler IDelegate1();
+        public delegate System.EventHandler iDelegate2();
     }
 }");
         }
@@ -37,38 +47,60 @@ namespace PublicApiGeneratorTests
             AssertPublicApi<ClassMemberOrderAndNestedClass>(
 @"namespace PublicApiGeneratorTests.Examples
 {
-    public class ClassMemberOrderAndNestedClass
+        public class ClassMemberOrderAndNestedClass
     {
         public int Field1;
         public int Field2;
+        public int IField1;
+        public int iField2;
         public ClassMemberOrderAndNestedClass() { }
+        public int IProperty1 { get; set; }
         public int Property1 { get; set; }
         public int Property2 { get; set; }
+        public int iProperty2 { get; set; }
         public event System.EventHandler Event1;
         public event System.EventHandler Event2;
+        public event System.EventHandler IEvent1;
+        public event System.EventHandler iEvent2;
+        public void IMethod1() { }
         public void Method1() { }
         public void Method2() { }
+        public void iMethod2() { }
         public class AnotherNestedClass
         {
             public int Field;
+            public int IField;
+            public int iField;
             public AnotherNestedClass() { }
         }
         public class ClassMemberOrderAsNestedClass
         {
             public int Field1;
             public int Field2;
+            public int IField1;
+            public int iField2;
             public ClassMemberOrderAsNestedClass() { }
+            public int IProperty1 { get; set; }
             public int Property1 { get; set; }
             public int Property2 { get; set; }
+            public int iProperty2 { get; set; }
             public event System.EventHandler Event1;
             public event System.EventHandler Event2;
+            public event System.EventHandler IEvent1;
+            public event System.EventHandler iEvent2;
+            public void IMethod1() { }
             public void Method1() { }
             public void Method2() { }
+            public void iMethod2() { }
             public delegate System.EventHandler Delegate11();
             public delegate System.EventHandler Delegate21();
+            public delegate System.EventHandler IDelegate11();
+            public delegate System.EventHandler iDelegate21();
         }
         public delegate System.EventHandler Delegate1();
         public delegate System.EventHandler Delegate2();
+        public delegate System.EventHandler iDelegate1();
+        public delegate System.EventHandler iDelegate2();
     }
 }");
         }
@@ -84,60 +116,92 @@ namespace PublicApiGeneratorTests
         {
             public int Field2;
             public int Field1;
+            public int iField2;
+            public int IField1;
 
             public event EventHandler Event2;
             public event EventHandler Event1;
+            public event EventHandler iEvent2;
+            public event EventHandler IEvent1;
 
             public delegate EventHandler Delegate2();
             public delegate EventHandler Delegate1();
+            public delegate EventHandler iDelegate2();
+            public delegate EventHandler IDelegate1();
 
             public int Property2 { get; set; }
             public int Property1 { get; set; }
+            public int iProperty2 { get; set; }
+            public int IProperty1 { get; set; }
 
             public void Method2() { }
             public void Method1() { }
+            public void iMethod2() { }
+            public void IMethod1() { }
         }
 
         public class ClassMemberOrderAndNestedClass
         {
             public int Field2;
             public int Field1;
+            public int iField2;
+            public int IField1;
 
             public event EventHandler Event2;
             public event EventHandler Event1;
+            public event EventHandler iEvent2;
+            public event EventHandler IEvent1;
 
             public delegate EventHandler Delegate2();
+            public delegate EventHandler iDelegate2();
 
             public class ClassMemberOrderAsNestedClass
             {
                 public int Field2;
                 public int Field1;
+                public int iField2;
+                public int IField1;
 
                 public event EventHandler Event2;
                 public event EventHandler Event1;
+                public event EventHandler iEvent2;
+                public event EventHandler IEvent1;
 
                 public delegate EventHandler Delegate21();
                 public delegate EventHandler Delegate11();
+                public delegate EventHandler iDelegate21();
+                public delegate EventHandler IDelegate11();
 
                 public int Property2 { get; set; }
                 public int Property1 { get; set; }
+                public int iProperty2 { get; set; }
+                public int IProperty1 { get; set; }
 
                 public void Method2() { }
                 public void Method1() { }
+                public void iMethod2() { }
+                public void IMethod1() { }
             }
 
             public class AnotherNestedClass
             {
                 public int Field;
+                public int IField;
+                public int iField;
             }
 
             public delegate EventHandler Delegate1();
+            public delegate EventHandler iDelegate1();
 
             public int Property2 { get; set; }
             public int Property1 { get; set; }
+            public int iProperty2 { get; set; }
+            public int IProperty1 { get; set; }
 
             public void Method2() { }
             public void Method1() { }
+            public void iMethod2() { }
+            public void IMethod1() { }
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Class_order.cs
+++ b/src/PublicApiGeneratorTests/Class_order.cs
@@ -8,12 +8,16 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_output_classes_in_alphabetical_order()
         {
-            AssertPublicApi(new[] { typeof(MM_Class), typeof(ZZ_Class), typeof(AA_Class) },
+            AssertPublicApi(new[] { typeof(MM_Class), typeof(ZZ_Class), typeof(AA_Class), typeof(I_Class), typeof(i_Class) },
 @"namespace PublicApiGeneratorTests.Examples
 {
-    public class AA_Class
+   public class AA_Class
     {
         public AA_Class() { }
+    }
+    public class I_Class
+    {
+        public I_Class() { }
     }
     public class MM_Class
     {
@@ -22,6 +26,10 @@ namespace PublicApiGeneratorTests
     public class ZZ_Class
     {
         public ZZ_Class() { }
+    }
+    public class i_Class
+    {
+        public i_Class() { }
     }
 }");
         }
@@ -39,6 +47,14 @@ namespace PublicApiGeneratorTests
         }
 
         public class AA_Class
+        {
+        }
+
+        public class I_Class
+        {
+        }
+
+        public class i_Class
         {
         }
     }

--- a/src/PublicApiGeneratorTests/Field_order.cs
+++ b/src/PublicApiGeneratorTests/Field_order.cs
@@ -14,8 +14,10 @@ namespace PublicApiGeneratorTests
     public class FieldOrderExample
     {
         public int AA_Field;
+        public int I_Field;
         public string YY_Field;
         public int ZZ_Field;
+        public int i_Field;
         public FieldOrderExample() { }
     }
 }");
@@ -32,6 +34,8 @@ namespace PublicApiGeneratorTests
             public int ZZ_Field;
             public string YY_Field;
             public int AA_Field;
+            public int i_Field;
+            public int I_Field;
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Interface_member_order.cs
+++ b/src/PublicApiGeneratorTests/Interface_member_order.cs
@@ -15,12 +15,18 @@ namespace PublicApiGeneratorTests
 {
     public interface IInterfaceMemberOrder
     {
+        int IProperty1 { get; set; }
         int Property1 { get; set; }
         int Property2 { get; set; }
+        int iProperty2 { get; set; }
         public event System.EventHandler Event1;
         public event System.EventHandler Event2;
+        public event System.EventHandler IEvent1;
+        public event System.EventHandler iEvent2;
+        void IMethod1();
         void Method1();
         void Method2();
+        void iMethod2();
     }
 }");
         }
@@ -36,12 +42,18 @@ namespace PublicApiGeneratorTests
         {
             event EventHandler Event2;
             event EventHandler Event1;
+            event EventHandler iEvent2;
+            event EventHandler IEvent1;
 
             int Property2 { get; set; }
             int Property1 { get; set; }
+            int iProperty2 { get; set; }
+            int IProperty1 { get; set; }
 
             void Method2();
             void Method1();
+            void iMethod2();
+            void IMethod1();
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Interface_order.cs
+++ b/src/PublicApiGeneratorTests/Interface_order.cs
@@ -8,12 +8,14 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_output_interfaces_in_alphabetical_order()
         {
-            AssertPublicApi(new[] { typeof(MM_Interface), typeof(ZZ_Interface), typeof(AA_Interface) },
+            AssertPublicApi(new[] { typeof(MM_Interface), typeof(ZZ_Interface), typeof(AA_Interface), typeof(I_Interface), typeof(i_Interface) },
 @"namespace PublicApiGeneratorTests.Examples
 {
     public interface AA_Interface { }
+    public interface I_Interface { }
     public interface MM_Interface { }
     public interface ZZ_Interface { }
+    public interface i_Interface { }
 }");
         }
     }
@@ -30,6 +32,12 @@ namespace PublicApiGeneratorTests
         }
 
         public interface AA_Interface
+        {
+        }
+        public interface I_Interface
+        {
+        }
+        public interface i_Interface
         {
         }
     }

--- a/src/PublicApiGeneratorTests/Method_order.cs
+++ b/src/PublicApiGeneratorTests/Method_order.cs
@@ -16,6 +16,8 @@ namespace PublicApiGeneratorTests
         public MethodOrdering() { }
         public void Method_AA() { }
         public void Method_BB() { }
+        public void Method_I() { }
+        public void Method_i() { }
     }
 }");
         }
@@ -32,6 +34,14 @@ namespace PublicApiGeneratorTests
             }
 
             public void Method_AA()
+            {
+            }
+
+            public void Method_I()
+            {
+            }
+
+            public void Method_i()
             {
             }
         }

--- a/src/PublicApiGeneratorTests/Struct_member_order.cs
+++ b/src/PublicApiGeneratorTests/Struct_member_order.cs
@@ -17,14 +17,24 @@ namespace PublicApiGeneratorTests
     {
         public int Field1;
         public int Field2;
+        public int IField2;
+        public int iField1;
+        public int IProperty2 { get; set; }
         public int Property1 { get; set; }
         public int Property2 { get; set; }
+        public int iProperty1 { get; set; }
         public event System.EventHandler Event1;
         public event System.EventHandler Event2;
+        public event System.EventHandler IEvent2;
+        public event System.EventHandler iEvent1;
+        public void IMethod2() { }
         public void Method1() { }
         public void Method2() { }
+        public void iMethod1() { }
         public delegate System.EventHandler Delegate1();
         public delegate System.EventHandler Delegate2();
+        public delegate System.EventHandler IDelegate2();
+        public delegate System.EventHandler iDelegate1();
     }
 }");
         }
@@ -40,32 +50,54 @@ namespace PublicApiGeneratorTests
     {
         public int Field1;
         public int Field2;
+        public int IField2;
+        public int iField1;
+        public int IProperty2 { get; set; }
         public int Property1 { get; set; }
         public int Property2 { get; set; }
+        public int iProperty1 { get; set; }
         public event System.EventHandler Event1;
         public event System.EventHandler Event2;
+        public event System.EventHandler IEvent2;
+        public event System.EventHandler iEvent1;
+        public void IMethod2() { }
         public void Method1() { }
         public void Method2() { }
+        public void iMethod1() { }
         public struct AnotherNestedStruct
         {
             public int Field;
+            public int IField;
+            public int iField;
         }
         public class ClassMemberOrderAsNestedClass
         {
             public int Field1;
             public int Field2;
+            public int IField2;
+            public int iField1;
             public ClassMemberOrderAsNestedClass() { }
+            public int IProperty2 { get; set; }
             public int Property1 { get; set; }
             public int Property2 { get; set; }
+            public int iProperty1 { get; set; }
             public event System.EventHandler Event1;
             public event System.EventHandler Event2;
+            public event System.EventHandler IEvent2;
+            public event System.EventHandler iEvent1;
+            public void IMethod2() { }
             public void Method1() { }
             public void Method2() { }
+            public void iMethod1() { }
             public delegate System.EventHandler Delegate11();
             public delegate System.EventHandler Delegate21();
+            public delegate System.EventHandler IDelegate21();
+            public delegate System.EventHandler iDelegate11();
         }
         public delegate System.EventHandler Delegate1();
         public delegate System.EventHandler Delegate2();
+        public delegate System.EventHandler IDelegate2();
+        public delegate System.EventHandler iDelegate1();
     }
 }");
         }
@@ -80,60 +112,92 @@ namespace PublicApiGeneratorTests
         {
             public int Field2;
             public int Field1;
+            public int IField2;
+            public int iField1;
 
             public event EventHandler Event2;
             public event EventHandler Event1;
+            public event EventHandler IEvent2;
+            public event EventHandler iEvent1;
 
             public delegate EventHandler Delegate2();
             public delegate EventHandler Delegate1();
+            public delegate EventHandler IDelegate2();
+            public delegate EventHandler iDelegate1();
 
             public int Property2 { get; set; }
             public int Property1 { get; set; }
+            public int IProperty2 { get; set; }
+            public int iProperty1 { get; set; }
 
             public void Method2() { }
             public void Method1() { }
+            public void IMethod2() { }
+            public void iMethod1() { }
         }
 
         public struct StructMemberOrderAndNestedClass
         {
             public int Field2;
             public int Field1;
+            public int IField2;
+            public int iField1;
 
             public event EventHandler Event2;
             public event EventHandler Event1;
+            public event EventHandler IEvent2;
+            public event EventHandler iEvent1;
 
             public delegate EventHandler Delegate2();
+            public delegate EventHandler IDelegate2();
 
             public class ClassMemberOrderAsNestedClass
             {
                 public int Field2;
                 public int Field1;
+                public int IField2;
+                public int iField1;
 
                 public event EventHandler Event2;
                 public event EventHandler Event1;
+                public event EventHandler IEvent2;
+                public event EventHandler iEvent1;
 
                 public delegate EventHandler Delegate21();
                 public delegate EventHandler Delegate11();
+                public delegate EventHandler IDelegate21();
+                public delegate EventHandler iDelegate11();
 
                 public int Property2 { get; set; }
                 public int Property1 { get; set; }
+                public int IProperty2 { get; set; }
+                public int iProperty1 { get; set; }
 
                 public void Method2() { }
                 public void Method1() { }
+                public void IMethod2() { }
+                public void iMethod1() { }
             }
 
             public struct AnotherNestedStruct
             {
                 public int Field;
+                public int IField;
+                public int iField;
             }
 
             public delegate EventHandler Delegate1();
+            public delegate EventHandler iDelegate1();
 
             public int Property2 { get; set; }
             public int Property1 { get; set; }
+            public int IProperty2 { get; set; }
+            public int iProperty1 { get; set; }
 
             public void Method2() { }
             public void Method1() { }
+            public void IMethod2() { }
+            public void iMethod1() { }
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Struct_order.cs
+++ b/src/PublicApiGeneratorTests/Struct_order.cs
@@ -8,12 +8,14 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_output_structs_in_alphabetical_order()
         {
-            AssertPublicApi(new[] { typeof(ZZ_Struct), typeof(AA_Struct), typeof(MM_Struct) },
+            AssertPublicApi(new[] { typeof(ZZ_Struct), typeof(AA_Struct), typeof(MM_Struct), typeof(I_Struct), typeof(i_Struct) },
 @"namespace PublicApiGeneratorTests.Examples
 {
     public struct AA_Struct { }
+    public struct I_Struct { }
     public struct MM_Struct { }
     public struct ZZ_Struct { }
+    public struct i_Struct { }
 }");
         }
     }
@@ -30,6 +32,14 @@ namespace PublicApiGeneratorTests
         }
 
         public struct MM_Struct
+        {
+        }
+
+        public struct I_Struct
+        {
+        }
+
+        public struct i_Struct
         {
         }
     }


### PR DESCRIPTION
Closes #56 