### PR TITLE
Output protected internal access modifier as protected

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -620,16 +620,12 @@ namespace PublicApiGenerator
         static MemberAttributes GetMethodAttributes(MethodDefinition method)
         {
             MemberAttributes access = 0;
-            if (method.IsFamily)
+            if (method.IsFamily || method.IsFamilyOrAssembly)
                 access = MemberAttributes.Family;
             if (method.IsPublic)
                 access = MemberAttributes.Public;
             if (method.IsAssembly)
                 access = MemberAttributes.Assembly;
-            if (method.IsFamilyAndAssembly)
-                access = MemberAttributes.FamilyAndAssembly;
-            if (method.IsFamilyOrAssembly)
-                access = MemberAttributes.FamilyOrAssembly;
 
             MemberAttributes scope = 0;
             if (method.IsStatic)
@@ -764,7 +760,8 @@ namespace PublicApiGenerator
         static bool HasVisiblePropertyMethod(MemberAttributes attributes)
         {
             var access = attributes & MemberAttributes.AccessMask;
-            return access == MemberAttributes.Public || access == MemberAttributes.Family ||
+            return access == MemberAttributes.Public ||
+                   access == MemberAttributes.Family ||
                    access == MemberAttributes.FamilyOrAssembly;
         }
 
@@ -789,7 +786,7 @@ namespace PublicApiGenerator
             MemberAttributes attributes = 0;
             if (memberInfo.HasConstant)
                 attributes |= MemberAttributes.Const;
-            if (memberInfo.IsFamily)
+            if (memberInfo.IsFamily || memberInfo.IsFamilyOrAssembly)
                 attributes |= MemberAttributes.Family;
             if (memberInfo.IsPublic)
                 attributes |= MemberAttributes.Public;

--- a/src/PublicApiGeneratorTests/Field_visibility.cs
+++ b/src/PublicApiGeneratorTests/Field_visibility.cs
@@ -14,6 +14,7 @@ namespace PublicApiGeneratorTests
     public class ClassWithFields
     {
         protected int protectedFieldIsVisible;
+        protected int protectedInternalFieldIsVisible;
         public int publicFieldIsVisible;
         public ClassWithFields() { }
     }
@@ -35,6 +36,7 @@ namespace PublicApiGeneratorTests
             internal int internalFieldNotVisible;
 
             protected int protectedFieldIsVisible;
+            protected internal int protectedInternalFieldIsVisible;
             public int publicFieldIsVisible;
         }
     }

--- a/src/PublicApiGeneratorTests/Method_visibility.cs
+++ b/src/PublicApiGeneratorTests/Method_visibility.cs
@@ -47,6 +47,20 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_show_protected_internal_methods()
+        {
+            AssertPublicApi<ClassWithProtectedInternalMethod>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithProtectedInternalMethod
+    {
+        public ClassWithProtectedInternalMethod() { }
+        protected void DoSomething() { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_not_show_private_methods()
         {
             AssertPublicApi<ClassWithPrivateMethod>(
@@ -86,9 +100,16 @@ namespace PublicApiGeneratorTests
             }
         }
 
+        public class ClassWithProtectedInternalMethod
+        {
+            protected internal void DoSomething()
+            {
+            }
+        }
+
         public class ClassWithPrivateMethod
         {
-            private void Method()
+            private void DoSomething()
             {
             }
         }

--- a/src/PublicApiGeneratorTests/Property_visibility.cs
+++ b/src/PublicApiGeneratorTests/Property_visibility.cs
@@ -42,7 +42,7 @@ namespace PublicApiGeneratorTests
     public class ClassWithProtectedInternalProperty
     {
         public ClassWithProtectedInternalProperty() { }
-        protected internal string Value { get; set; }
+        protected string Value { get; set; }
     }
 }");
         }
@@ -244,7 +244,7 @@ namespace PublicApiGeneratorTests
     public class ClassWithProtectedInternalGetterPublicSetter
     {
         public ClassWithProtectedInternalGetterPublicSetter() { }
-        public string Value1 { protected internal get; set; }
+        public string Value1 { protected get; set; }
     }
 }");
         }


### PR DESCRIPTION
At the moment members marked with the `protected internal` access modifier are output inconsistently:
- Fields get no modifier
- Methods and properties get `protected internal`

Since the `internal` part of `protected internal` doesn't apply to the public API, I think all `protected internal` members should be output like they are just marked `protected`.

I've provided a fix and added/updated unit tests. Let me know if there is anything else you'd like me to do.