### PR TITLE
WIP: Fix out parameter generic types

### DIFF
--- a/src/PublicApiGeneratorTests/Method_parameters.cs
+++ b/src/PublicApiGeneratorTests/Method_parameters.cs
@@ -174,6 +174,36 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_output_out_parameter_with_generic_type()
+        {
+            AssertPublicApi<MethodWithOutGenericTypeParameter>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class MethodWithOutGenericTypeParameter
+    {
+        public MethodWithOutGenericTypeParameter() { }
+        public void Method(out PublicApiGeneratorTests.Examples.GenericType<int> value) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_out_parameter_fully_qualified_type_name_for_generic_parameter()
+        {
+            AssertPublicApi<MethodWithOutGenericTypeOfComplexTypeParameter>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class MethodWithOutGenericTypeOfComplexTypeParameter
+    {
+        public MethodWithOutGenericTypeOfComplexTypeParameter() { }
+        public void Method(out PublicApiGeneratorTests.Examples.GenericType<PublicApiGeneratorTests.Examples.ComplexType> value) { }
+    }
+}");
+        }
+
+        //
+
+        [Fact]
         public void Should_output_params_keyword()
         {
             AssertPublicApi<MethodWithParams>(
@@ -266,6 +296,22 @@ namespace PublicApiGeneratorTests
         public class MethodWithOutParameter
         {
             public void Method(out string value)
+            {
+                value = null;
+            }
+        }
+
+        public class MethodWithOutGenericTypeParameter
+        {
+            public void Method(out GenericType<int> value)
+            {
+                value = null;
+            }
+        }
+
+        public class MethodWithOutGenericTypeOfComplexTypeParameter
+        {
+            public void Method(out GenericType<ComplexType> value)
             {
                 value = null;
             }

--- a/src/PublicApiGeneratorTests/Method_parameters.cs
+++ b/src/PublicApiGeneratorTests/Method_parameters.cs
@@ -188,6 +188,20 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_output_out_parameter_with_generic_enumerable()
+        {
+            AssertPublicApi<MethodWithOutGenericTypeParameterEnumerable>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class MethodWithOutGenericTypeParameterEnumerable
+    {
+        public MethodWithOutGenericTypeParameterEnumerable() { }
+        public void Method(out System.Collections.Generic.IEnumerable<int> value) { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_output_out_parameter_fully_qualified_type_name_for_generic_parameter()
         {
             AssertPublicApi<MethodWithOutGenericTypeOfComplexTypeParameter>(
@@ -304,6 +318,14 @@ namespace PublicApiGeneratorTests
         public class MethodWithOutGenericTypeParameter
         {
             public void Method(out GenericType<int> value)
+            {
+                value = null;
+            }
+        }
+
+        public class MethodWithOutGenericTypeParameterEnumerable
+        {
+            public void Method(out System.Collections.Generic.IEnumerable<int> value)
             {
                 value = null;
             }


### PR DESCRIPTION
I just upgraded to 9.2.0 in Castle Core, thanks for the release.

After the changes in #69 for generic constraints, I have now noticed that our `out` parameters didn't have their generic parameters specified before (e.g. `IEnumerable<>` was the parameter type), but are now outputting the generic constraint name (or `!n`) rather than being populated with the type from the parameter.

```csharp
// Input:
public void Method(out GenericType<int> value) { }
public void Method(out IEnumerable<int> value) { }
public void Method(out GenericType<ComplexType> value) { }

// Output:
public void Method(out GenericType<T> value) { }
public void Method(out IEnumerable<!0> value) { }
public void Method(out GenericType<T> value) { }
```

I've included the unit tests I wrote in this draft pull request so people are aware of the defect. I tried quickly to fix the problem but couldn't see how to fix it. I'll return to it again next week, if you have any tips on what you think might be the cause happy to listen.