### PR TITLE
Add support for default keyword for non primitive structs

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -644,9 +644,15 @@ namespace PublicApiGenerator
             }
         }
 
-        static object FormatParameterConstant(IConstantProvider parameter)
+        static object FormatParameterConstant(ParameterDefinition parameter)
         {
-            return parameter.Constant is string ? string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameter.Constant) : (parameter.Constant ?? "null");
+            if (parameter.Constant is string)
+                return string.Format(CultureInfo.InvariantCulture, "\"{0}\"", parameter.Constant);
+
+            if (parameter.Constant != null)
+                return parameter.Constant;
+
+            return parameter.ParameterType.IsValueType ? "default" : "null";
         }
 
         static MemberAttributes GetMethodAttributes(MethodDefinition method)

--- a/src/PublicApiGeneratorTests/Method_parameters.cs
+++ b/src/PublicApiGeneratorTests/Method_parameters.cs
@@ -1,4 +1,5 @@
 ﻿using PublicApiGeneratorTests.Examples;
+using System.Threading;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -168,7 +169,7 @@ namespace PublicApiGeneratorTests
     public class MethodWithDefaultValues
     {
         public MethodWithDefaultValues() { }
-        public void Method(int value1 = 42, string value2 = ""hello world"") { }
+        public void Method(int value1 = 42, string value2 = ""hello world"", System.Threading.CancellationToken token = default, int value3 = 0, string value4 = null) { }
     }
 }");
         }
@@ -351,7 +352,7 @@ namespace PublicApiGeneratorTests
 
         public class MethodWithDefaultValues
         {
-            public void Method(int value1 = 42, string value2 = "hello world")
+            public void Method(int value1 = 42, string value2 = "hello world", CancellationToken token = default, int value3 = default, string value4 = default)
             {
             }
         }


### PR DESCRIPTION
I noticed that ApiApprover generates `CancellationToken token = null` for such common API like `public static Task DoSomething(CancellationToken token = default)`. It's obvious that `null` is invalid default value for struct.